### PR TITLE
nodebrew→fnm移行

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -13,9 +13,6 @@ case Darwin
   # pyenv用の設定
   eval (pyenv init --path)
 
-  # node用の設定
-  set -x PATH $HOME/.nodebrew/current/bin $PATH
-
   # 独自コマンドのパスを通す
   set -x PATH $PATH ~/dotfiles/bin
 


### PR DESCRIPTION
## 概要
nodeのバージョン管理を`nodebrew`→`fnm`に移行する。

## 修正内容
* nodebrewのパスを通していた処理を削除

## 備考
#47 