### PR TITLE
fish初回起動時のpyenv設定コマンド修正

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -11,7 +11,7 @@ case Linux
 case Darwin
   set OS 'Mac OS'
   # pyenv用の設定
-  eval (pyenv init --path)
+  eval (pyenv init --path | source)
 
   # node用の設定
   set -x PATH $HOME/.nodebrew/current/bin $PATH


### PR DESCRIPTION
## 概要

設定コマンドが誤っていたため修正

## 修正内容

## 備考
