### PR TITLE
Javaのデフォルトバージョンを固定するように修正

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -12,6 +12,9 @@ case Darwin
   set OS 'Mac OS'
   # pyenv用の設定
   eval (pyenv init --path | source)
+  
+  # Javaのデフォルトバージョンを18で指定
+  set -x JAVA_HOME (/usr/libexec/java_home -v 18)
 
   # 独自コマンドのパスを通す
   set -x PATH $PATH ~/dotfiles/bin


### PR DESCRIPTION
## 概要
Javaのデフォルトバージョンを18で固定する。

## 修正内容

## 備考
