### PR TITLE
Neovimのカラースキームを設定する

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -22,55 +22,10 @@ vim.opt.hlsearch = true                           -- 検索ワードのハイラ
 -- netrw
 vim.g.netrw_preview = 1                           -- プレビューウィンドウを垂直分割で表示する
 
+-- カラースキームの読み込みと設定
+require('colors')
 
--- カラースキーム
-
--- 対応括弧の色
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight MatchParen ctermfg=0 ctermbg=21 guifg=Black guibg=Blue1",
-})
-
--- 行番号の色
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight LineNr ctermfg=lightmagenta",
-})
-
--- コメントの色
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight Comment ctermfg=243",
-})
-
--- 通常の文字色
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight Normal ctermfg=248",
-})
-
--- ポップアップメニュー(通常の項目)
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight Pmenu ctermfg=232 ctermbg=255",
-})
-
--- ポップアップメニュー(選択中の項目)
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight PmenuSel ctermfg=41 ctermbg=54",
-})
-
--- ビジュアルモード選択
-vim.api.nvim_create_autocmd({"ColorScheme"},{
-  pattern = {"*"},
-  command = "highlight Visual ctermbg=239",
-})
-
-vim.g.hybrid_custom_term_colors = 1               -- iTerm2用のhybrid設定
-vim.cmd("colorscheme hybrid")
-
--- プラグイン
+-- プラグイン設定
 require('plugins')
 
 vim.opt.helplang = 'ja,en'                        -- ヘルプの言語を日本語優先にする

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,5 +1,4 @@
--- TODO: プラグイン設定
-
+-- 基本設定
 vim.opt.number = true                             -- 行番号を表示
 vim.opt.title = true                              -- ファイル名を表示
 vim.opt.smartcase = true                          -- 小文字で検索時、大文字小文字を無視する
@@ -22,6 +21,54 @@ vim.opt.hlsearch = true                           -- 検索ワードのハイラ
 
 -- netrw
 vim.g.netrw_preview = 1                           -- プレビューウィンドウを垂直分割で表示する
+
+
+-- カラースキーム
+
+-- 対応括弧の色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight MatchParen ctermfg=0 ctermbg=21 guifg=Black guibg=Blue1",
+})
+
+-- 行番号の色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight LineNr ctermfg=lightmagenta",
+})
+
+-- コメントの色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Comment ctermfg=243",
+})
+
+-- 通常の文字色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Normal ctermfg=248",
+})
+
+-- ポップアップメニュー(通常の項目)
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Pmenu ctermfg=232 ctermbg=255",
+})
+
+-- ポップアップメニュー(選択中の項目)
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight PmenuSel ctermfg=41 ctermbg=54",
+})
+
+-- ビジュアルモード選択
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Visual ctermbg=239",
+})
+
+vim.g.hybrid_custom_term_colors = 1               -- iTerm2用のhybrid設定
+vim.cmd("colorscheme hybrid")
 
 -- プラグイン
 require('plugins')

--- a/.config/nvim/lua/colors.lua
+++ b/.config/nvim/lua/colors.lua
@@ -1,3 +1,5 @@
+-- カラースキームに関する設定ファイル
+
 -- 対応括弧の色
 vim.api.nvim_create_autocmd({"ColorScheme"},{
   pattern = {"*"},

--- a/.config/nvim/lua/colors.lua
+++ b/.config/nvim/lua/colors.lua
@@ -1,0 +1,44 @@
+-- 対応括弧の色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight MatchParen ctermfg=0 ctermbg=21 guifg=Black guibg=Blue1",
+})
+
+-- 行番号の色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight LineNr ctermfg=lightmagenta",
+})
+
+-- コメントの色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Comment ctermfg=243",
+})
+
+-- 通常の文字色
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Normal ctermfg=248",
+})
+
+-- ポップアップメニュー(通常の項目)
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Pmenu ctermfg=232 ctermbg=255",
+})
+
+-- ポップアップメニュー(選択中の項目)
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight PmenuSel ctermfg=41 ctermbg=54",
+})
+
+-- ビジュアルモード選択
+vim.api.nvim_create_autocmd({"ColorScheme"},{
+  pattern = {"*"},
+  command = "highlight Visual ctermbg=239",
+})
+
+vim.g.hybrid_custom_term_colors = 1               -- iTerm2用のhybrid設定
+vim.cmd("colorscheme hybrid")

--- a/etc/init
+++ b/etc/init
@@ -5,11 +5,33 @@ DOTPATH="${HOME}/dotfiles"
 
 cd ${DOTPATH}
 
+# 必要なコマンドがインストールされているかチェックする
+function check_command() {
+  if !(type "wget" > /dev/null 2>&1); then
+    echo 'wget command is not exist'
+    exit 1
+  else
+    echo 'all necessary commands are already installd!'
+  fi
+}
+
 # カラースキームのデータをダウンロードする
 function download_vim_color() {
   # hybridのカラースキームをダウンロードする
   if [ ! -f ${DOTPATH}/.vim/colors/hybrid.vim ]; then
     wget https://raw.githubusercontent.com/w0ng/vim-hybrid/master/colors/hybrid.vim -P ${DOTPATH}/.vim/colors/
+  fi
+}
+
+# Neovim用のカラースキームデータをダウンロードする
+function download_nvim_color() {
+  # Neovim用カラースキームの保存先
+  local NVIM_COLOR_DIR="${HOME}/.config/nvim/colors"
+
+  if [ ! -f ${NVIM_COLOR_DIR} ]; then
+    wget https://raw.githubusercontent.com/w0ng/vim-hybrid/master/colors/hybrid.vim -P ${NVIM_COLOR_DIR}/
+  else
+    echo 'hybrid.vim is already installed.'
   fi
 }
 
@@ -45,8 +67,14 @@ function fzf_install() {
 # main関数
 # インストールなどの初期設定のみを行う
 function main () {
+  # コマンドの存在チェク
+  check_command
+
   # vimのカラースキームをダウンロード
   # download_vim_color
+
+  # Neovimのカラースキームをインストール
+  download_nvim_color
 
   # Neovimのプラグインマネージャーをインストール
   download_packer_nvim

--- a/etc/init
+++ b/etc/init
@@ -28,6 +28,8 @@ function download_nvim_color() {
   # Neovim用カラースキームの保存先
   local NVIM_COLOR_DIR="${HOME}/.config/nvim/colors"
 
+  echo 'install color scheme for Neovim'
+
   if [ ! -f ${NVIM_COLOR_DIR} ]; then
     wget https://raw.githubusercontent.com/w0ng/vim-hybrid/master/colors/hybrid.vim -P ${NVIM_COLOR_DIR}/
   else


### PR DESCRIPTION
## 概要
Neovimのカラースキームを`hybrid`に設定

## 修正内容
* 基本的には`.vimrc`からの移行作業
* `etc/init`にて、コマンドチェックを行う

## 備考
