### PR TITLE
ログ出力処理のバグ修正

### DIFF
--- a/etc/init
+++ b/etc/init
@@ -10,10 +10,10 @@ cd ${DOTPATH}
 # 必要なコマンドがインストールされているかチェックする
 function check_command() {
   if !(type "wget" > /dev/null 2>&1); then
-    echo 'wget command is not exist'
+    log -l error "wget command is not exist"
     exit 1
   else
-    echo 'all necessary commands are already installd!'
+    log "all necessary commands are already installd!"
   fi
 }
 
@@ -30,31 +30,32 @@ function download_nvim_color() {
   # Neovim用カラースキームの保存先
   local NVIM_COLOR_DIR="${HOME}/.config/nvim/colors"
 
-  echo 'install color scheme for Neovim'
+  log "install color scheme for Neovim"
 
   if [ ! -f ${NVIM_COLOR_DIR}/hybrid.vim ]; then
     wget https://raw.githubusercontent.com/w0ng/vim-hybrid/master/colors/hybrid.vim -P ${NVIM_COLOR_DIR}/
   else
-    echo 'hybrid.vim is already installed.'
+    log "hybrid.vim is already installed."
   fi
 }
 
 # Neovimのプラグインマネージャーをインストールする
 function download_packer_nvim() {
   local PACKER_DIR="${HOME}/.local/share/nvim/site/pack/packer/start/packer.nvim"
-  echo 'install packer.nvim'
+
+  log "install packer.nvim"
 
   if [ ! -d ${PACKER_DIR} ]; then
     git clone --depth 1 https://github.com/wbthomason/packer.nvim ${PACKER_DIR}
   else
-    echo 'packer.nvim is already installed.'
+    log "packer.nvim is already installed."
   fi
 }
 
 function fzf_install() {
   # fzfコマンドのインストール
   if !(type fzf > /dev/null 2>&1); then
-    echo 'install fzf...'
+    log "install fzf..."
     # Macの場合はhomebrewを使ってインストールする
     case "$(uname)" in
       'Darwin')

--- a/etc/init
+++ b/etc/init
@@ -3,6 +3,8 @@ set -eu
 
 DOTPATH="${HOME}/dotfiles"
 
+. ${DOTPATH}/etc/logger.sh
+
 cd ${DOTPATH}
 
 # 必要なコマンドがインストールされているかチェックする
@@ -30,7 +32,7 @@ function download_nvim_color() {
 
   echo 'install color scheme for Neovim'
 
-  if [ ! -f ${NVIM_COLOR_DIR} ]; then
+  if [ ! -f ${NVIM_COLOR_DIR}/hybrid.vim ]; then
     wget https://raw.githubusercontent.com/w0ng/vim-hybrid/master/colors/hybrid.vim -P ${NVIM_COLOR_DIR}/
   else
     echo 'hybrid.vim is already installed.'

--- a/etc/logger.sh
+++ b/etc/logger.sh
@@ -18,12 +18,12 @@ function log () {
   done
 
   # オプション指定を位置パラメータから削除する
-  shift $(expr $OPTIND - 1)
-  # shift `expr $OPTIND - 1`
+  shift `expr $OPTIND - 1`
 
   local msg=$1
 
-  format_log ${level} ${msg}
+  # メッセージは空白文字が入っている可能性があるため、一つの文字列として渡す
+  format_log ${level} "${msg}"
 }
 
 # 色をつけて文字を出力する


### PR DESCRIPTION
## 概要
ログ出力の際、引数に空白を含む文字列を入れた場合
最初の単語しか出力されなかったため修正

## 修正内容
* 空白文字が入る可能性のあるシェルスクリプト変数を`""`で囲い、一つの文字列として表現
* echoを使った出力を、全てロガーを使った出力に置換

## 備考
