### PR TITLE
rancher desktop用のパスを通す

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -16,3 +16,7 @@ if type fish > /dev/null 2>&1; then
 else
   echo "exec bash!"
 fi
+
+### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
+export PATH="~/.rd/bin:$PATH"
+### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)

--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -19,6 +19,11 @@ case Darwin
   # 独自コマンドのパスを通す
   set -x PATH $PATH ~/dotfiles/bin
 
+### MANAGED BY RANCHER DESKTOP START (DO NOT EDIT)
+# set --export --prepend PATH "/Users/negita/.rd/bin"
+  set -x PATH $PATH ~/.rd/bin
+### MANAGED BY RANCHER DESKTOP END (DO NOT EDIT)
+
   # コマンドラインからググるコマンド
   function gg
     open -a /Applications/Google\ Chrome.app \
@@ -56,3 +61,4 @@ set __fish_git_prompt_char_upstream_behind '-'
 
 # fzfの古いキーバインディングを利用しない設定
 set -U FZF_LEGACY_KEYBINDINGS 0
+


### PR DESCRIPTION
## 概要
[Rancher Desktop](https://docs.rancherdesktop.io/)の設定として、パスを通す

## 修正内容
パスに`$HOME/.rd/bin`を追加

## 備考
* https://zenn.dev/miyajan/articles/migrate-from-docker-desktop-to-rancher-desktop
