### PR TITLE
ctrl+wで一つ前のスラッシュまで削除する

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -18,3 +18,6 @@ esac
 
 # 独自コマンドのパスを通す
 export PATH=$PATH:~/dotfiles/bin
+
+# ctrl+wで一つ前のスラッシュまで削除する
+export WORDCHARS='*?_.[]~-=&;!#$%^(){}<>'


### PR DESCRIPTION
## 概要
`ctrl+w`で補完されたパスが全て削除されてしまったので改善

## 修正内容
環境変数追加

## 備考
https://cameong.hatenablog.com/entry/20140321/1395377298
