### PR TITLE
feat: Google Cloud用のCLI設定

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -12,6 +12,10 @@ alias la='ls -laGF'
 # fnmの有効化
 eval "$(fnm env --use-on-cd)"
 
+# GoodleCloudの有効化
+source "$(brew --prefix)/share/google-cloud-sdk/path.zsh.inc"
+source "$(brew --prefix)/share/google-cloud-sdk/completion.zsh.inc"
+
 # git-promptの設定
 source ~/.git-prompt.sh
 


### PR DESCRIPTION
## 概要

## 修正内容
* brew経由でCLIインストール
* `.zshrc`に設定追加

## 備考
* https://formulae.brew.sh/cask/google-cloud-sdk
* https://zenn.dev/rabee/articles/gcloud-setup-with-homebrew-on-mac

## 残り作業
- [ ] CLI未インストール環境でも問題なく動作することを確認
