### PR TITLE
Neovimのプラグインマネージャーをlazy.nvimに変更

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -22,10 +22,23 @@ vim.opt.hlsearch = true                           -- 検索ワードのハイラ
 -- netrw
 vim.g.netrw_preview = 1                           -- プレビューウィンドウを垂直分割で表示する
 
+vim.opt.helplang = 'ja,en'                        -- ヘルプの言語を日本語優先にする
+
 -- カラースキームの読み込みと設定
 require('colors')
 
 -- プラグイン設定
-require('plugins')
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable", -- latest stable release
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+require('lazy').setup('plugins')
 
-vim.opt.helplang = 'ja,en'                        -- ヘルプの言語を日本語優先にする

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -1,6 +1,3 @@
-vim.cmd [[packadd packer.nvim]]
-
-return require('packer').startup(function(use)
-  use 'wbthomason/packer.nvim'
-  use 'vim-jp/vimdoc-ja'
-end)
+return {
+  'vim-jp/vimdoc-ja'
+}

--- a/.config/nvim/lua/plugins.lua
+++ b/.config/nvim/lua/plugins.lua
@@ -1,3 +1,10 @@
 return {
-  'vim-jp/vimdoc-ja'
+  'vim-jp/vimdoc-ja',
+  {
+    'numToStr/Comment.nvim',
+    lazy = false,
+    init = function()
+      require('Comment').setup()
+    end,
+  }
 }

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,46 @@
+" 基本
+set helplang=ja,en                              "ヘルプの言語を日本語優先にする
+set number                                      "行番号を表示
+set title                                       "ファイル名を表示
+set pumheight=10                                "補完メニューの高さ
+set smartcase                                   "小文字で検索時、大文字小文字を無視する
+"set relativenumber                              " 行番号をカーソルからの相対指定にする
+set nowrap                                      " 行の折り返しを無効にする
+
+" 括弧
+set showmatch                                   "括弧入力時の対応する括弧を表示
+set matchtime=1                                 "対応括弧に飛ぶ時間を0.1x1秒に設定
+
+" ステータスライン
+set laststatus=2                                " ステータスラインを常に表示する
+set statusline=%F                               " ファイル名表示
+let &statusline .= ' [%{cfi#format("%s", "")}]' " 関数名表示
+set statusline+=%r                              " 読み込み専用かどうかを表示
+set statusline+=%=                              " これ以降は右寄せ表示
+set statusline+=[BF=%n]                         " バッファ番号
+set statusline+=[LOW=%l/%L]                     " 現在行数/全行数
+set statusline+=%y                              " ファイルタイプ表示
+
+" ハイライト
+set hlsearch                                    " 検索ワードのハイライトを行う
+syntax on                                       "シンタックスハイライト
+au BufRead,BufNewFile *.scss set filetype=sass  "scssのシンタックスハイライト
+syntax enable                                   "構文チェック
+
+" タブ、インデント
+set tabstop=2                                   "タブの文字幅
+set shiftwidth=2                                "自動インデントの幅
+set smartindent                                 "一つ前の行に基づくインデント
+set expandtab                                   "タブ入力を空白にする
+set list                                        "listオプションを有効にする
+set listchars=tab:»-,trail:-,nbsp:%             "listオプションを設定する
+
+" コマンドライン
+" <C-p>, <C-n>でフィルタリングしながらコマンドラインの補完を行う
+cnoremap <C-p> <Up>
+cnoremap <C-n> <Down>
+set wildmenu                                    "入力候補を表示する
+
+" netrw
+let g:netrw_preview=1                             " プレビューウィンドウを垂直分割で表示する
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ iTerm2 で利用する設定ファイルを配置
 |          名称          |             説明             |
 | :--------------------: | :--------------------------: |
 |  [vim-jp/vimdoc-ja][]  |       ヘルプの日本語化       |
+|  [Comment.nvim][]      |     簡単にコメントアウト     |
 
 
 ## fish
@@ -97,6 +98,7 @@ $ fisher add jethrokuan/fzf
 
 [lazy.nvim]: (https://github.com/folke/lazy.nvim)
 [vim-jp/vimdoc-ja]: https://github.com/vim-jp/vimdoc-ja
+[Comment.nvim]: (https://github.com/numToStr/Comment.nvim)
 [tpope/vim-fugitive]: https://github.com/tpope/vim-fugitive
 [posva/vim-vue]: https://github.com/posva/vim-vue
 [jethrokuan/fzf]: https://github.com/jethrokuan/fzf

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ iTerm2 で利用する設定ファイルを配置
 ## Vim
 
 - color scheme : hybrid
-- plugin : vim-plug
+- plugin manager : [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ### plugin for Vim
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ iTerm2 で利用する設定ファイルを配置
 ## Vim
 
 - color scheme : hybrid
-- plugin manager : [lazy.nvim](https://github.com/folke/lazy.nvim)
+- plugin manager : [lazy.nvim][]
 
 ### plugin for Vim
 
@@ -95,6 +95,7 @@ $ fisher add jethrokuan/fzf
 | [zsh-users/zsh-syntax-highlighting][] | シンタックスハイライト     |
 | [junegunn/fzf][]                      | あいまい検索をする         |
 
+[lazy.nvim]: (https://github.com/folke/lazy.nvim)
 [vim-jp/vimdoc-ja]: https://github.com/vim-jp/vimdoc-ja
 [tpope/vim-fugitive]: https://github.com/tpope/vim-fugitive
 [posva/vim-vue]: https://github.com/posva/vim-vue

--- a/etc/init
+++ b/etc/init
@@ -39,19 +39,6 @@ function download_nvim_color() {
   fi
 }
 
-# Neovimのプラグインマネージャーをインストールする
-function download_packer_nvim() {
-  local PACKER_DIR="${HOME}/.local/share/nvim/site/pack/packer/start/packer.nvim"
-
-  log "install packer.nvim"
-
-  if [ ! -d ${PACKER_DIR} ]; then
-    git clone --depth 1 https://github.com/wbthomason/packer.nvim ${PACKER_DIR}
-  else
-    log "packer.nvim is already installed."
-  fi
-}
-
 # zshのプラグインマネージャーをインストールする
 function download_zsh_plugin_manager() {
   local ZPLUG_DIR="${HOME}/.zplug"
@@ -102,9 +89,6 @@ function main () {
 
   # Neovimのカラースキームをインストール
   download_nvim_color
-
-  # Neovimのプラグインマネージャーをインストール
-  download_packer_nvim
 
   # fzfのインストール
   fzf_install


### PR DESCRIPTION
## 概要
close issue #70 

## 修正内容
* `packer.nvim`の設定削除
* `lazy.nvim`導入
* `Comment.nvim`導入
* `.vimrc`を簡易化して復活

## 備考
