### PR TITLE
vim-matchupにより、開始タグと終了タグの対応を可視化する

### DIFF
--- a/.config/nvim/lua/plugins/vim-matchup.lua
+++ b/.config/nvim/lua/plugins/vim-matchup.lua
@@ -3,10 +3,6 @@ return {
   event = { "BufReadPost" },  -- ファイル読み込み後に遅延ロード
   config = function()
     -- === 可視化のみを有効化 ===
-
-    -- 対応するタグのハイライトを有効化
-    vim.g.matchup_matchparen_enabled = 1
-
     -- 移動機能を無効化 (%キーは標準Vimの動作)
     vim.g.matchup_motion_enabled = 0
 
@@ -14,20 +10,20 @@ return {
     vim.g.matchup_text_obj_enabled = 0
 
     -- === パフォーマンス最適化 ===
-
-    -- 非同期処理で遅延を防止
+    -- 非同期処理でカーソル移動の遅延を防止
     vim.g.matchup_matchparen_deferred = 1
 
-    -- ハイライト更新タイミング (ミリ秒)
-    vim.g.matchup_matchparen_timeout = 300          -- 通常モード
-    vim.g.matchup_matchparen_insert_timeout = 60    -- インサートモード
-
     -- === 画面外マッチの表示 ===
-
     -- 対応タグが画面外の場合、ポップアップで表示
     vim.g.matchup_matchparen_offscreen = {
       method = "popup",
       fullwidth = 1,
     }
+
+    -- === ハイライトスタイルのカスタマイズ ===
+    vim.api.nvim_set_hl(0, 'MatchParen', {
+      underline = true,  -- 下線を引く
+      bg = '#3e4451', -- 背景色を変更する場合
+    })
   end,
 }


### PR DESCRIPTION
## 概要

## 修正内容

## 備考
