### PR TITLE
fix: WezTermのOSC133プロンプトゾーンの範囲を修正

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -60,15 +60,16 @@ zplug load
 # 「直前のコマンド行 + その出力」を Leader+o でコピーできるようにするための土台。
 # シェルが要所でエスケープシーケンス(OSC 133)を出力し、WezTerm がそれを読んで
 # 「プロンプト/入力/出力」の範囲(Semantic Zone)を認識できるようにする。
-#   A: プロンプト開始 / B: 入力開始 / C: コマンド実行=出力開始 / D: コマンド終了
+#   A: プロンプト開始(PS1先頭) / B: 入力開始(PS1末尾) / C: コマンド実行=出力開始(preexec) / D: コマンド終了(precmd)
 if [[ "$TERM_PROGRAM" == "WezTerm" ]]; then
   autoload -Uz add-zsh-hook
 
-  # コマンド実行後・次のプロンプト表示の直前に毎回呼ばれる
+  # コマンド実行後・次のプロンプト表示の直前に毎回呼ばれる。
+  # ここでは直前コマンドの終了(D)のみ出力する。プロンプト開始(A)は precmd で出すと
+  # 「これから描くプロンプト行」に Output ゾーンが食い込むため、PS1 の先頭に置く（下記）。
   __wezterm_osc133_precmd() {
     local exit_code=$?
     print -n "\e]133;D;${exit_code}\a"   # 直前コマンドの終了（終了コード付き）
-    print -n "\e]133;A\a"                # 次のプロンプトの開始
   }
   # Enter押下後・コマンド実行の直前に呼ばれる
   __wezterm_osc133_preexec() {
@@ -77,8 +78,10 @@ if [[ "$TERM_PROGRAM" == "WezTerm" ]]; then
   add-zsh-hook precmd  __wezterm_osc133_precmd
   add-zsh-hook preexec __wezterm_osc133_preexec
 
-  # プロンプト末尾に B（入力開始）マーカーを付与する。
+  # A（プロンプト開始）を PS1 先頭、B（入力開始）を PS1 末尾に付与する。
+  # これにより Prompt ゾーンの範囲が明確になり、Output ゾーンが次プロンプト行へ食い込まない。
   # %{ %} は「表示幅ゼロの制御文字」であることを zsh に伝える囲み（折返し計算用）。
+  __wezterm_osc133_a=$'\e]133;A\a'
   __wezterm_osc133_b=$'\e]133;B\a'
-  PS1="${PS1}%{${__wezterm_osc133_b}%}"
+  PS1="%{${__wezterm_osc133_a}%}${PS1}%{${__wezterm_osc133_b}%}"
 fi


### PR DESCRIPTION
## 概要

WezTermのSemantic Zone(OSC 133)において、プロンプト開始マーカー(A)の出力位置を修正しました。

## 変更内容

- プロンプト開始(A)を `precmd` フックではなく `PS1` の先頭に出力するように変更
- `precmd` では直前コマンドの終了(D)のみを出力
- A を PS1 先頭、B を PS1 末尾に配置することで Prompt ゾーンの範囲を明確化

## 背景・理由

`precmd` で A を出力すると「これから描くプロンプト行」に Output ゾーンが食い込んでしまう問題があった。A を PS1 先頭に置くことで、Output ゾーンが次のプロンプト行へ食い込まないようにする。

🤖 Generated with [Claude Code](https://claude.com/claude-code)